### PR TITLE
Triggering SticsRTests only for the commits on main

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -72,7 +72,7 @@ jobs:
     name: Trigger SticsRTest check
     # Publish main when the test job succeeds and it's not a pull request.
     needs: R-CMD-check
-    if: needs.R-CMD-check.result == 'success'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.R-CMD-check.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger


### PR DESCRIPTION
Because SticsRTests uses the code from the main branch, so there is no use for triggering it for each commit in a pull request, as it will not use the code of the PR for the tests, giving a false sense of the test.

In the future, we should make it possible to run it from the PR, but it may be tricky because we need to send the name of the PR with the trigger, and adapt the branch we need to checkout for the package tested on SticsRTests