### PR TITLE
fix: check-standard.yaml: R version from 4.0.0 to 4.1.0 (for pak comp…

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -33,7 +33,7 @@ jobs:
             }
           - {
               os: ubuntu-latest,
-              r: "4.0.0",
+              r: "4.1.0",
               rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest",
             }
 


### PR DESCRIPTION
One of the checks in github fails because it can't install packages due to the installed R version. I think it should be updated in SticsOnR since it is in the other packages.