### PR TITLE
fix: improve get_version parsing to support relaxed version formats

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -51,7 +51,6 @@ jobs:
           extra-packages: |
             any::rcmdcheck
             SticsRPacks/SticsRFiles@main
-            github::r-lib/testthat@3.1.8
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -50,10 +50,13 @@ references:
   url: https://www.R-project.org/
   authors:
   - name: R Core Team
+    website: https://ror.org/02zz1nj61
   institution:
     name: R Foundation for Statistical Computing
+    website: https://ror.org/05qewa988
     address: Vienna, Austria
   year: '2026'
+  doi: 10.32614/R.manuals
   version: '>= 3.6.0'
 - type: software
   title: cli
@@ -151,10 +154,13 @@ references:
   notes: Imports
   authors:
   - name: R Core Team
+    website: https://ror.org/02zz1nj61
   institution:
     name: R Foundation for Statistical Computing
+    website: https://ror.org/05qewa988
     address: Vienna, Austria
   year: '2026'
+  doi: 10.32614/R.manuals
 - type: software
   title: rstudioapi
   abstract: 'rstudioapi: Safely Access the RStudio API'
@@ -182,10 +188,13 @@ references:
   notes: Imports
   authors:
   - name: R Core Team
+    website: https://ror.org/02zz1nj61
   institution:
     name: R Foundation for Statistical Computing
+    website: https://ror.org/05qewa988
     address: Vienna, Austria
   year: '2026'
+  doi: 10.32614/R.manuals
 - type: software
   title: tibble
   abstract: 'tibble: Simple Data Frames'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,4 +61,4 @@ ByteCompile: true
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-Config/roxygen2/version: 8.0.0
+RoxygenNote: 7.3.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,4 +61,4 @@ ByteCompile: true
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/R/stics_exe_utilities.R
+++ b/R/stics_exe_utilities.R
@@ -381,9 +381,10 @@ get_version_date <- function(version_object) {
 }
 
 get_version <- function(version_line, numeric = TRUE) {
-
   date_string <- extract_version_date(version_line)
-  if (is.na(date_string)) return(NA)
+  if (is.na(date_string)) {
+    return(NA)
+  }
 
   date_object <- as.Date(date_string)
 

--- a/R/stics_exe_utilities.R
+++ b/R/stics_exe_utilities.R
@@ -381,101 +381,107 @@ get_version_date <- function(version_object) {
 }
 
 get_version <- function(version_line, numeric = TRUE) {
-  # getting the version date
+
   date_string <- extract_version_date(version_line)
-  # no date detected
-  if (is.na(date_string)) {
-    return(NA)
-  }
-  # converting to Date
+  if (is.na(date_string)) return(NA)
+
   date_object <- as.Date(date_string)
 
-  # trying to get the hash if any & early return
   version_hash <- extract_version_hash(version_line)
-  if (!is.na((version_hash))) {
+  if (!is.na(version_hash)) {
     attr(version_hash, "date") <- date_object
     return(version_hash)
   }
 
-  # Trying to get the release number
-  if (!grepl(pattern = "stics", x = tolower(version_line))) {
-    warning(
-      "The version information returned by the executable is not a STICS one"
-    )
-    return(NA)
-  }
-  # Rewriting the version (which may be incomplete, i.e. 10.5)
-  # as a full version (with 3 digits x.y.z) to be
-  # able to parse it as a semver object
-  version_object <- complete_version(
-    extract_version_string(version_line)
-  )
-  if (numeric) {
-    version_object <- semver::parse_version(version_object)
-  }
-  # Adding date as attribute to the semver object or character version
-  attr(version_object, "date") <- date_object
+  version_raw <- extract_version_string(version_line)
 
-  version_object
+  if (!is.na(version_raw)) {
+    version_full <- complete_version(version_raw)
+
+    if (numeric) {
+      version_object <- semver::parse_version(version_full)
+    } else {
+      version_object <- sub("^v", "", version_full)
+    }
+
+    attr(version_object, "date") <- date_object
+    return(version_object)
+  }
+
+  version_label <- extract_version_label(version_line)
+  if (!is.na(version_label)) {
+    attr(version_label, "date") <- date_object
+    return(version_label)
+  }
+
+  NA
 }
 
 extract_version_string <- function(version_string) {
-  if (!grepl(pattern = "v[0-9\\.]*", version_string)) {
-    return(NA)
-  }
-  gsub(
-    pattern = "(.*v)([0-9\\.]*)(.*)",
-    replacement = "\\2",
-    x = trimws(tolower(version_string))
+  version_string <- tolower(trimws(version_string))
+
+  match <- regmatches(
+    version_string,
+    regexpr("v[0-9]+\\.[0-9]+\\.[0-9]+(?:-[a-z0-9.]+)?", version_string)
   )
+
+  if (length(match) == 0 || match == "") {
+    return(NA_character_)
+  }
+
+  sub("^v", "", match)
 }
 
 extract_version_hash <- function(version_string) {
   version_string <- trimws(tolower(version_string))
-  if (
-    !grepl(
-      pattern = "^[[:alnum:]]{8,9}_",
-      x = version_string
-    )
-  ) {
-    return(NA)
+
+  if (!grepl("^[[:alnum:]]{8,9}_", version_string)) {
+    return(NA_character_)
   }
-  gsub(
-    pattern = "(^[[:alnum:]]{8,9})(_.*)",
-    x = version_string,
-    replacement = "\\1"
-  )
+
+  sub("^([[:alnum:]]{8,9})_.*", "\\1", version_string)
+}
+
+extract_version_label <- function(version_string) {
+  version_string <- trimws(tolower(version_string))
+
+  if (!grepl("^.+_[0-9]{4}-[0-9]{2}-[0-9]{2}$", version_string)) {
+    return(NA_character_)
+  }
+
+  sub("_[0-9]{4}-[0-9]{2}-[0-9]{2}$", "", version_string)
 }
 
 extract_version_date <- function(version_string) {
-  if (
-    !grepl(
-      pattern = "[0-9]{4}-[0-9]{2}-[0-9]{2}",
-      x = trimws(tolower(version_string))
-    )
-  ) {
+  version_string <- trimws(tolower(version_string))
+
+  if (!grepl("[0-9]{4}-[0-9]{2}-[0-9]{2}", version_string)) {
     return(NA)
   }
-  gsub(
-    pattern = "(.*)([0-9]{4}-[0-9]{2}-[0-9]{2})",
-    x = version_string,
-    replacement = "\\2"
-  )
+
+  sub(".*([0-9]{4}-[0-9]{2}-[0-9]{2}).*", "\\1", version_string)
 }
 
 complete_version <- function(stics_version) {
-  if (is.numeric(stics_version)) stics_version <- as.character(stics_version)
-
-  version_parts <- strsplit(stics_version, split = ".", fixed = TRUE)[[1]]
-  version_parts_number <- length(version_parts)
-  if (version_parts_number == 2) {
-    replic <- 1
-  } else if (version_parts_number == 1) {
-    replic <- 2
-  } else {
-    return(stics_version)
+  if (is.numeric(stics_version)) {
+    stics_version <- as.character(stics_version)
   }
-  paste(c(version_parts, rep("0", replic)), collapse = ".")
+
+  if (is.na(stics_version) || stics_version == "") {
+    return(NA)
+  }
+
+  version_parts <- strsplit(stics_version, "\\.", fixed = FALSE)[[1]]
+
+  if (length(version_parts) == 2) {
+    return(paste0(stics_version, ".0"))
+  }
+
+  if (length(version_parts) == 1) {
+    return(paste0(stics_version, ".0.0"))
+  }
+
+  stics_version
 }
 
 

--- a/R/stics_exe_utilities.R
+++ b/R/stics_exe_utilities.R
@@ -337,10 +337,11 @@ list_stics_exe <- function(javastics) {
 #' @param numeric Logical, `TRUE` (default) to return a numeric version as a
 #' semver class vector, or `FALSE` to return a character string with the version
 #'
-#' @returns a smvr class vector if `numeric = TRUE` (default),
+#' @returns a semver class vector if `numeric = TRUE` (default),
 #' or a character string if `numeric = FALSE`, with an attribute "date" if
 #' the version date is provided in the system command output.
 #' Or a hash string if the system command output contains a hash.
+#' Or a label string if neither a version number nor a hash is found.
 #' @export
 #'
 #' @examples

--- a/R/stics_wrapper.R
+++ b/R/stics_wrapper.R
@@ -276,324 +276,323 @@ stics_wrapper <- function(
     .export = c("run_stics", "select_results"),
     .packages = c("SticsRFiles"),
     .combine = "c"
-  ) %do_par_or_not%
-    {
-      ## Loops on the USMs that can be simulated
-      ## out is a list containing vectors of:
-      ##   o list of simulated outputs,
-      ##   o flag TRUE if the requested simulation has been not performed
-      ##                        (model error),
-      ##   o flag FALSE if all the requested dates and variables were
-      ##     not simulated,
-      ##   o message in case of warning or error
-      ## (one value per set of parameter values to force)
+  ) %do_par_or_not% {
+    ## Loops on the USMs that can be simulated
+    ## out is a list containing vectors of:
+    ##   o list of simulated outputs,
+    ##   o flag TRUE if the requested simulation has been not performed
+    ##                        (model error),
+    ##   o flag FALSE if all the requested dates and variables were
+    ##     not simulated,
+    ##   o message in case of warning or error
+    ## (one value per set of parameter values to force)
 
-      rotation <- rotations[[i]]
-      rotation_out <- list()
-      for (j in seq_along(rotation)) {
-        situation <- rotation[j]
-        run_dir <- file.path(workspace, situation)
+    rotation <- rotations[[i]]
+    rotation_out <- list()
+    for (j in seq_along(rotation)) {
+      situation <- rotation[j]
+      run_dir <- file.path(workspace, situation)
 
-        # Select param_values depending on the situation to simulate
-        # convert param_values in a tibble if needed
-        param_values_sit <- tibble::tibble(!!!param_values)
-        if (!is.null(param_values)) {
-          if ("situation" %in% names(param_values_sit)) {
-            param_values_sit <- param_values_sit %>%
-              dplyr::filter(situation == situation) %>%
-              dplyr::select(-situation)
-          }
-          if ("variete" %in% names(param_values_sit)) {
-            param_values_sit <- dplyr::select(
-              param_values_sit,
-              c(
-                "variete",
-                setdiff(
-                  names(param_values_sit),
-                  "variete"
-                )
+      # Select param_values depending on the situation to simulate
+      # convert param_values in a tibble if needed
+      param_values_sit <- tibble::tibble(!!!param_values)
+      if (!is.null(param_values)) {
+        if ("situation" %in% names(param_values_sit)) {
+          param_values_sit <- param_values_sit %>%
+            dplyr::filter(situation == situation) %>%
+            dplyr::select(-situation)
+        }
+        if ("variete" %in% names(param_values_sit)) {
+          param_values_sit <- dplyr::select(
+            param_values_sit,
+            c(
+              "variete",
+              setdiff(
+                names(param_values_sit),
+                "variete"
               )
             )
-          }
+          )
         }
-        if (is.null((param_values_sit)) || nrow(param_values_sit) == 0) {
-          param_values_sit <- tibble::tibble(NA)
+      }
+      if (is.null((param_values_sit)) || nrow(param_values_sit) == 0) {
+        param_values_sit <- tibble::tibble(NA)
+      }
+
+      # Initialize out content
+      sim_list <- vector("list", nrow(param_values_sit))
+      flag_error <- rep(FALSE, nrow(param_values_sit))
+      flag_rqd_res <- rep(TRUE, nrow(param_values_sit))
+      messages <- as.list(rep("", nrow(param_values_sit)))
+
+      # For each set of parameter values to force in the model
+      for (ip in seq_len(nrow(param_values_sit))) {
+        # Force parameters values
+        if (
+          !SticsRFiles::force_param_values(
+            run_dir,
+            dplyr::slice(param_values_sit, ip),
+            javastics
+          )
+        ) {
+          mess <- warning(paste(
+            "Error when generating the forcing parameters file for USM",
+            situation,
+            ". \n "
+          ))
+          sim_list[ip] <- NULL
+          flag_error[ip] <- TRUE
+          flag_rqd_res[ip] <- FALSE
+          messages[ip] <- mess
+          next()
         }
 
-        # Initialize out content
-        sim_list <- vector("list", nrow(param_values_sit))
-        flag_error <- rep(FALSE, nrow(param_values_sit))
-        flag_rqd_res <- rep(TRUE, nrow(param_values_sit))
-        messages <- as.list(rep("", nrow(param_values_sit)))
-
-        # For each set of parameter values to force in the model
-        for (ip in seq_len(nrow(param_values_sit))) {
-          # Force parameters values
-          if (
-            !SticsRFiles::force_param_values(
-              run_dir,
-              dplyr::slice(param_values_sit, ip),
-              javastics
+        # Handle the simulation (may be repeated - using flag simulate - in case
+        # some configuration files are not well defined)
+        varmod_modified <- FALSE
+        simulate <- TRUE
+        while (simulate) {
+          is_successive <- is_successive_usm(successive, situation)
+          if (is_successive) {
+            previous_run_dir <- file.path(workspace, rotation[j - 1])
+            # Checking recup.tmp and snow_variables.txt files
+            # recup.tmp file is mandatory
+            f_recup_prev <- file.path(
+              previous_run_dir,
+              paste0("recup", ip, ".tmp")
             )
-          ) {
-            mess <- warning(paste(
-              "Error when generating the forcing parameters file for USM",
-              situation,
-              ". \n "
-            ))
-            sim_list[ip] <- NULL
-            flag_error[ip] <- TRUE
-            flag_rqd_res[ip] <- FALSE
-            messages[ip] <- mess
-            next()
-          }
 
-          # Handle the simulation (may be repeated - using flag simulate - in case
-          # some configuration files are not well defined)
-          varmod_modified <- FALSE
-          simulate <- TRUE
-          while (simulate) {
-            is_successive <- is_successive_usm(successive, situation)
-            if (is_successive) {
-              previous_run_dir <- file.path(workspace, rotation[j - 1])
-              # Checking recup.tmp and snow_variables.txt files
-              # recup.tmp file is mandatory
-              f_recup_prev <- file.path(
-                previous_run_dir,
-                paste0("recup", ip, ".tmp")
-              )
-
-              # Add snow_variables.txt to be copied only if snow is used
-              # in the previous usm
-              # (use_snow == 1, i.e. codesnow == 1 in the USM input file)
-              use_snow_prev <- suppressWarnings(
-                unlist(
-                  SticsRFiles::get_param_txt(
-                    workspace = previous_run_dir,
-                    param = "codesnow",
-                    exact = TRUE
-                  ),
-                  use.names = FALSE
-                )
-              )
-              # check if snow module is used for the current usm
-              use_snow_curr <- suppressWarnings(
-                unlist(
-                  SticsRFiles::get_param_txt(
-                    workspace = run_dir,
-                    param = "codesnow",
-                    exact = TRUE
-                  ),
-                  use.names = FALSE
-                )
-              )
-
-              # manage consistency for snow module use for the 2 successive usms
-              if (use_snow_prev != use_snow_curr) {
-                if (use_snow_prev == 1) {
-                  mess_snow <- c(
-                    "but snow module is not used in the current USM",
-                    "while it was used in the previous USM."
-                  )
-                } else {
-                  mess_snow <- c(
-                    "but snow module is used in the current USM",
-                    "while it was not used in the previous USM."
-                  )
-                }
-                mess_snow <- warning(paste(
-                  "Error running the Stics model for USM",
-                  situation,
-                  ". \n This USM is part of a succession",
-                  mess_snow[1],
-                  mess_snow[2]
-                ))
-              } else {
-                mess_snow <- NULL
-              }
-
-              if (use_snow_prev == 1) {
-                # previous snow_variables.txt file
-                snow_prev <- file.path(
-                  previous_run_dir,
-                  paste0("snow_variables", ip, ".txt")
-                )
-                f_recup_prev <- c(f_recup_prev, snow_prev)
-              }
-              f_exist <- file.exists(f_recup_prev)
-
-              if (!all(f_exist)) {
-                mess <- warning(paste(
-                  "Error running the Stics model for USM",
-                  situation,
-                  ". \n This USMs is part of a succession",
-                  "but recup.tmp or snow_variables.txt",
-                  "file(s) was/were not created by the previous USM: \n",
-                  paste(f_recup_prev[f_exist], collapse = ", ")
-                ))
-                stop(paste(mess_snow, "\n\n", mess))
-              }
-
-              # Copying needed files and checking return
-              recup_copy <- file.copy(
-                from = f_recup_prev[f_exist],
-                to = file.path(
-                  run_dir,
-                  gsub(
-                    pattern = "[0-9*]",
-                    x = basename(f_recup_prev[f_exist]),
-                    replacement = ""
-                  )
+            # Add snow_variables.txt to be copied only if snow is used
+            # in the previous usm
+            # (use_snow == 1, i.e. codesnow == 1 in the USM input file)
+            use_snow_prev <- suppressWarnings(
+              unlist(
+                SticsRFiles::get_param_txt(
+                  workspace = previous_run_dir,
+                  param = "codesnow",
+                  exact = TRUE
                 ),
-                overwrite = TRUE
+                use.names = FALSE
               )
-
-              if (!all(recup_copy)) {
-                mess <- warning(
-                  paste(
-                    "Error copying recup.tmp and/or",
-                    "snow_variables.txt file(s) for USM",
-                    situation
-                  )
-                )
-
-                sim_list[ip] <- NULL
-                flag_error[ip] <- TRUE
-                flag_rqd_res[ip] <- FALSE
-                messages[ip] <- mess
-                next()
-              }
-              # The following could be done only once in case of repeated call
-              # to the wrapper (e.g. parameters estimation ...)
-              # new_travail.usm file must be modified to allow successive USMs
-              # file path
-              new_travail <- file.path(run_dir, "new_travail.usm")
-              SticsRFiles::set_usm_txt(
-                file = new_travail,
-                param = "codesuite",
-                value = 1
+            )
+            # check if snow module is used for the current usm
+            use_snow_curr <- suppressWarnings(
+              unlist(
+                SticsRFiles::get_param_txt(
+                  workspace = run_dir,
+                  param = "codesnow",
+                  exact = TRUE
+                ),
+                use.names = FALSE
               )
-            }
-
-            # Run the model, forcing not to check the model executable
-            # (saves time)
-            usm_out <- run_stics(
-              stics_exe,
-              run_dir,
-              verbose = verbose,
-              check = FALSE
             )
 
-            # In case of successive USMs, re-initialize codesuite (to allow next
-            # run to be in non-successive mode) and rename recup.tmp and
-            # snow_variables.txt (for usms that have a successor)
-            if (is_successive) {
-              SticsRFiles::set_usm_txt(
-                file = new_travail,
-                param = "codesuite",
-                value = 0
-              )
-            }
-
-            if (is_previous_usm(successive, situation)) {
-              recup_curr <- file.path(run_dir, "recup.tmp")
-
-              if (!file.exists(recup_curr)) {
-                stop("recup.tmp file not found")
-              }
-
-              file.rename(
-                from = recup_curr,
-                to = file.path(run_dir, paste0("recup", ip, ".tmp"))
-              )
-
-              snow_curr <- file.path(run_dir, "snow_variables.txt")
-
-              if (file.exists(snow_curr)) {
-                file.rename(
-                  from = snow_curr,
-                  to = file.path(run_dir, paste0("snow_variables", ip, ".txt"))
+            # manage consistency for snow module use for the 2 successive usms
+            if (use_snow_prev != use_snow_curr) {
+              if (use_snow_prev == 1) {
+                mess_snow <- c(
+                  "but snow module is not used in the current USM",
+                  "while it was used in the previous USM."
+                )
+              } else {
+                mess_snow <- c(
+                  "but snow module is used in the current USM",
+                  "while it was not used in the previous USM."
                 )
               }
+              mess_snow <- warning(paste(
+                "Error running the Stics model for USM",
+                situation,
+                ". \n This USM is part of a succession",
+                mess_snow[1],
+                mess_snow[2]
+              ))
+            } else {
+              mess_snow <- NULL
             }
 
-            # if the model returns an error, ... go to next simulation
-            if (usm_out[[1]]$error) {
+            if (use_snow_prev == 1) {
+              # previous snow_variables.txt file
+              snow_prev <- file.path(
+                previous_run_dir,
+                paste0("snow_variables", ip, ".txt")
+              )
+              f_recup_prev <- c(f_recup_prev, snow_prev)
+            }
+            f_exist <- file.exists(f_recup_prev)
+
+            if (!all(f_exist)) {
               mess <- warning(paste(
                 "Error running the Stics model for USM",
                 situation,
-                ". \n ",
-                usm_out[[1]]$message
+                ". \n This USMs is part of a succession",
+                "but recup.tmp or snow_variables.txt",
+                "file(s) was/were not created by the previous USM: \n",
+                paste(f_recup_prev[f_exist], collapse = ", ")
               ))
-              sim_list[[ip]] <- NULL
-              flag_error[ip] <- TRUE
-              flag_rqd_res[ip] <- FALSE
-              messages[[ip]] <- mess
-              simulate <- FALSE
-              next()
+              stop(paste(mess_snow, "\n\n", mess))
             }
 
-            # Get results
-            sim_tmp <- SticsRFiles::get_sim(run_dir, verbose = verbose)[[1]]
-
-            # Any error reading output file ... go to next simulation
-            if (is.null(sim_tmp)) {
-              mess <- warning(paste(
-                "Error reading outputs for ",
-                situation,
-                ". \n "
-              ))
-              sim_list[[ip]] <- NULL
-              flag_error[ip] <- TRUE
-              flag_rqd_res[ip] <- FALSE
-              messages[[ip]] <- mess
-              simulate <- FALSE
-              next()
-            }
-
-            # For phenological stages, replace the zeros by the following non-zero
-            # value (works even in case of simulations replicated on several years
-            # within a single USM)
-            if (length(sim_tmp) > 0) {
-              if (length(intersect(stages_list, names(sim_tmp)) > 0)) {
-                sim_tmp <-
-                  sim_tmp %>%
-                  dplyr::mutate(
-                    dplyr::across(
-                      dplyr::all_of(
-                        intersect(stages_list, names(.))
-                      ),
-                      ~ dplyr::na_if(., 0)
-                    ) %>%
-                      tidyr::fill(tidyr::everything(), .direction = "up")
-                  )
-              }
-            }
-
-            # Select data to return
-            tmp <- select_results(
-              keep_all_data,
-              sit_var_dates_mask,
-              var,
-              dates,
-              situation,
-              sim_tmp,
-              varmod_modified,
-              verbose,
-              run_dir
+            # Copying needed files and checking return
+            recup_copy <- file.copy(
+              from = f_recup_prev[f_exist],
+              to = file.path(
+                run_dir,
+                gsub(
+                  pattern = "[0-9*]",
+                  x = basename(f_recup_prev[f_exist]),
+                  replacement = ""
+                )
+              ),
+              overwrite = TRUE
             )
-            sim_list[[ip]] <- tmp$sim_list
-            flag_error[ip] <- tmp$flag_error
-            flag_rqd_res[ip] <- tmp$flag_rqd_res
-            messages[[ip]] <- tmp$message
-            simulate <- tmp$simulate
-            varmod_modified <- tmp$varmod_modified
+
+            if (!all(recup_copy)) {
+              mess <- warning(
+                paste(
+                  "Error copying recup.tmp and/or",
+                  "snow_variables.txt file(s) for USM",
+                  situation
+                )
+              )
+
+              sim_list[ip] <- NULL
+              flag_error[ip] <- TRUE
+              flag_rqd_res[ip] <- FALSE
+              messages[ip] <- mess
+              next()
+            }
+            # The following could be done only once in case of repeated call
+            # to the wrapper (e.g. parameters estimation ...)
+            # new_travail.usm file must be modified to allow successive USMs
+            # file path
+            new_travail <- file.path(run_dir, "new_travail.usm")
+            SticsRFiles::set_usm_txt(
+              file = new_travail,
+              param = "codesuite",
+              value = 1
+            )
           }
+
+          # Run the model, forcing not to check the model executable
+          # (saves time)
+          usm_out <- run_stics(
+            stics_exe,
+            run_dir,
+            verbose = verbose,
+            check = FALSE
+          )
+
+          # In case of successive USMs, re-initialize codesuite (to allow next
+          # run to be in non-successive mode) and rename recup.tmp and
+          # snow_variables.txt (for usms that have a successor)
+          if (is_successive) {
+            SticsRFiles::set_usm_txt(
+              file = new_travail,
+              param = "codesuite",
+              value = 0
+            )
+          }
+
+          if (is_previous_usm(successive, situation)) {
+            recup_curr <- file.path(run_dir, "recup.tmp")
+
+            if (!file.exists(recup_curr)) {
+              stop("recup.tmp file not found")
+            }
+
+            file.rename(
+              from = recup_curr,
+              to = file.path(run_dir, paste0("recup", ip, ".tmp"))
+            )
+
+            snow_curr <- file.path(run_dir, "snow_variables.txt")
+
+            if (file.exists(snow_curr)) {
+              file.rename(
+                from = snow_curr,
+                to = file.path(run_dir, paste0("snow_variables", ip, ".txt"))
+              )
+            }
+          }
+
+          # if the model returns an error, ... go to next simulation
+          if (usm_out[[1]]$error) {
+            mess <- warning(paste(
+              "Error running the Stics model for USM",
+              situation,
+              ". \n ",
+              usm_out[[1]]$message
+            ))
+            sim_list[[ip]] <- NULL
+            flag_error[ip] <- TRUE
+            flag_rqd_res[ip] <- FALSE
+            messages[[ip]] <- mess
+            simulate <- FALSE
+            next()
+          }
+
+          # Get results
+          sim_tmp <- SticsRFiles::get_sim(run_dir, verbose = verbose)[[1]]
+
+          # Any error reading output file ... go to next simulation
+          if (is.null(sim_tmp)) {
+            mess <- warning(paste(
+              "Error reading outputs for ",
+              situation,
+              ". \n "
+            ))
+            sim_list[[ip]] <- NULL
+            flag_error[ip] <- TRUE
+            flag_rqd_res[ip] <- FALSE
+            messages[[ip]] <- mess
+            simulate <- FALSE
+            next()
+          }
+
+          # For phenological stages, replace the zeros by the following non-zero
+          # value (works even in case of simulations replicated on several years
+          # within a single USM)
+          if (length(sim_tmp) > 0) {
+            if (length(intersect(stages_list, names(sim_tmp)) > 0)) {
+              sim_tmp <-
+                sim_tmp %>%
+                dplyr::mutate(
+                  dplyr::across(
+                    dplyr::all_of(
+                      intersect(stages_list, names(.))
+                    ),
+                    ~ dplyr::na_if(., 0)
+                  ) %>%
+                    tidyr::fill(tidyr::everything(), .direction = "up")
+                )
+            }
+          }
+
+          # Select data to return
+          tmp <- select_results(
+            keep_all_data,
+            sit_var_dates_mask,
+            var,
+            dates,
+            situation,
+            sim_tmp,
+            varmod_modified,
+            verbose,
+            run_dir
+          )
+          sim_list[[ip]] <- tmp$sim_list
+          flag_error[ip] <- tmp$flag_error
+          flag_rqd_res[ip] <- tmp$flag_rqd_res
+          messages[[ip]] <- tmp$message
+          simulate <- tmp$simulate
+          varmod_modified <- tmp$varmod_modified
         }
-        rotation_out[[j]] <- list(sim_list, flag_error, flag_rqd_res, messages)
       }
-      return(rotation_out)
+      rotation_out[[j]] <- list(sim_list, flag_error, flag_rqd_res, messages)
     }
+    return(rotation_out)
+  }
 
   # Filtering situation names for keeping only the required results
   names(out) <- sit2simulate

--- a/tests/testthat/test-versions-info.R
+++ b/tests/testthat/test-versions-info.R
@@ -11,7 +11,7 @@ test_that("Get the version hash or date, date from the exe info", {
   version_line <- " stics_v10.4.1_2025-07-30"
   testthat::expect_equal(
     extract_version_hash(version_line),
-    NA
+    NA_character_
   )
   testthat::expect_equal(
     extract_version_date(version_line),
@@ -20,11 +20,29 @@ test_that("Get the version hash or date, date from the exe info", {
   version_line <- " Modulostics version : V10.0.0_r3391_2022-10-26"
   testthat::expect_equal(
     extract_version_hash(version_line),
-    NA
+    NA_character_
   )
   testthat::expect_equal(
     extract_version_date(version_line),
     "2022-10-26"
+  )
+})
+
+test_that("Get the version label from the exe info", {
+  version_line <- " test_name_2026-04-12"
+  testthat::expect_equal(
+    extract_version_label(version_line),
+    "test_name"
+  )
+  version_line <- " test_name"
+  testthat::expect_equal(
+    extract_version_label(version_line),
+    NA_character_
+  )
+  version_line <- " _2026-11-25"
+  testthat::expect_equal(
+    extract_version_label(version_line),
+    NA_character_
   )
 })
 
@@ -35,7 +53,7 @@ test_that("Get the full version from number or string", {
   testthat::expect_equal(complete_version("10.5.0"), "10.5.0")
 })
 
-test_that("Get the version hash from the executable info string", {
+test_that("Get the version from the executable info string", {
   version_line <- " b09f41236_2026-02-17"
   testthat::expect_equivalent(get_version(version_line), "b09f41236")
   testthat::expect_equivalent(
@@ -55,6 +73,18 @@ test_that("Get the version hash from the executable info string", {
   testthat::expect_equivalent(
     get_version(version_line, numeric = FALSE),
     "10.0.0"
+  )
+  version_line <- "v11.0.0-rc2_2026-06-11"
+  num_version <- semver::parse_version("11.0.0-rc2")
+  testthat::expect_equivalent(get_version(version_line), num_version)
+  testthat::expect_equivalent(
+    get_version(version_line, numeric = FALSE),
+    "11.0.0-rc2"
+  )
+  version_line <- "test_named_2026-06-11"
+  testthat::expect_equivalent(
+    get_version(version_line, numeric = FALSE),
+    "test_named"
   )
   version_line <- "   "
   testthat::expect_equal(get_version(version_line), NA)


### PR DESCRIPTION
get_version is now less strict when parsing version strings from STICS executables.
It no longer requires a “stics” pattern in the version line.
It now correctly interprets SemVer versions, including pre-release identifiers such as -rc1 (e.g. 11.0.0-rc1).
When no commit hash or SemVer version can be extracted, it returns the version label as-is.